### PR TITLE
Extend bucegi area to the north

### DIFF
--- a/src/data.coffee
+++ b/src/data.coffee
@@ -14,7 +14,7 @@ data = module.exports = {}
 
 
 data.REGION = {
-  bucegi:     {bbox: [25.36, 45.33, 25.58, 45.52], title: "Bucegi", meteoLink: "mun%C5%A3ii-bucegi_romania_683598"}
+  bucegi:     {bbox: [25.36, 45.33, 25.58, 45.53], title: "Bucegi", meteoLink: "mun%C5%A3ii-bucegi_romania_683598"}
   capatanii:  {bbox: [24.00, 45.17, 24.19, 45.34], title: "Căpățânii", meteoLink: "mun%C5%A3ii-c%C4%83p%C4%83%C5%A3%C3%A2nii_romania_682818"}
   ceahlau:    {bbox: [25.85, 46.84, 26.08, 47.04], title: "Ceahlău", meteoLink: "masivul-ceahl%C4%83u_romania_682481 "}
   ciucas:     {bbox: [25.84, 45.43, 26.05, 45.56], title: "Ciucaș", meteoLink: "ciucas_romania_7874266"}


### PR DESCRIPTION
This allows the map to catch some trails around Trei Brazi and Poiana Secuilor, such as the blue triangle to Pîrîul Rece or the yellow triangle to Timișul de Sus.

Do note that there are more trails to the north, until Cheile Râșnoavei and even Râșnov which are currently not caught in any map; although technically they're still in Bucegi (or so I think), I did not include them because I'm not sure of how you divide your maps. The proposed change is minimal and brings good value for casual visitors from Predeal.
